### PR TITLE
jenkinsfile and makefile

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,0 +1,21 @@
+@Library('common')
+import com.typecode.*
+
+node {
+  properties([disableConcurrentBuilds()])
+  
+  ps = new PipelineSteps()
+  
+  ps.checkout()
+  deploy()
+  ps.notifySuccess()
+}
+
+def deploy() {
+  stage('Deploy') {
+    sh '''
+      sudo make install
+    '''
+    ps.setBuildStatus('Deploy complete', 'SUCCESS')
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: clean-pyc clean-build install
+
+install:
+	python setup.py install --force
+
+clean:
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg-info
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +


### PR DESCRIPTION
Jenkins build should make [this line](https://github.com/typecode/sharp-ecommerce/blob/develop/Jenkinsfile.groovy#L63) unnecessary. Makefile makes housekeeping easier.
The Jenkinsfile uses functions defined here https://github.com/typecode/pipeline-library and made available by configuring jenkins here https://smash.typeco.de/configure.