### PR TITLE
Update sync pg data

### DIFF
--- a/create_readme.py
+++ b/create_readme.py
@@ -4,7 +4,7 @@ from sykle.config import Config
 import os
 import chevron
 
-PLUGINS_PATH = os.path.join(os.path.dirname(__file__), 'sykle.plugins')
+PLUGINS_PATH = os.path.join(os.path.dirname(__file__), 'sykle/plugins')
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'README.mustache')
 README_PATH = os.path.join(os.path.dirname(__file__), 'README.md')
 
@@ -22,6 +22,7 @@ def create_readme(template, destination, docstring):
 
     if os.path.isfile(destination):
         os.chmod(destination, 0o644)
+
     with open(destination, 'w+', encoding='utf-8') as f:
         f.write(long_description)
 

--- a/sykle/plugins/sync_pg_data/README.mustache
+++ b/sykle/plugins/sync_pg_data/README.mustache
@@ -2,13 +2,19 @@
 
 Wrapper around `pg_restore`, `pg_dump` and `psql` that allows you to sync data from one location to another.
 
-### Data only
+### Usage Instructions
 
-This command does NOT do a full database dump and restore. Dumps and restores DATA ONLY so we can sync apps that still have active connections. This means all tables in the source that you would like to link to the destination must be present.
+This command will sync BOTH data and the schema. This has a couple implications:
 
-### Truncation
-
-In order to avoid foreign key constraint errors when restoring data, any existing data must be removed. This means *THE ORIGINAL DESTINATION DATA WILL BE REMOVED*.
+- You will need to ensure that the place you are syncing FROM has code that is either the SAME or is OLDER than the place you are syncing to. Although you **COULD** dump data from a newer codebase into data from an older codebase, if the database schema has changed, the code and migrations will not work properly.
+  - `production -> staging` ✅
+  - `staging -> development` ✅
+  - `production -> development` ✅
+  - ~~`staging -> production`~~ ❌
+  - ~~`development -> staging`~~ ❌
+  - ~~`development -> production`~~ ❌
+- Any services using the destination database will need to be stopped. You can use the `dependent_services` section of the config to list docker-compose services that should automatically be stopped and restarted.
+- Syncing will DELETE all data in the destination database and replace it with data from the source. You can make a backup before syncing using the `dump` command
 
 ### Why put this in syk?
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -12,8 +12,8 @@ class ConfigTestCase(unittest.TestCase):
                 'staging': {
                     'target': 'some-target',
                     'docker_vars': {
-                        'non_env_var': 'thing',
-                        'env_var': '$ENV_VAR'
+                        'non_env_var': u'thing',
+                        'env_var': u'$ENV_VAR'
                     }
                 }
             }
@@ -33,8 +33,8 @@ class ConfigTestCase(unittest.TestCase):
 
     def test_interpolate_env_values(self):
         interpolated = Config.interpolate_env_values(
-            {'non_env_var': 'A', 'env_var': '$BUILD_NUMBER'},
-            {'BUILD_NUMBER': '1'}
+            {'non_env_var': 'A', 'env_var': u'$BUILD_NUMBER'},
+            {u'BUILD_NUMBER': u'1'}
         )
         self.assertEqual(
             interpolated,


### PR DESCRIPTION
### Overview

Migrations were being dumped from production and blowing away local migrations, which was messing up the db sync. Specifically, I had newer migrations locally that had been run and who's results where in the database, but those migrations weren't recorded. I had originally made the database dump data so it could be run while the app was running/connections were active, but I overlooked that migration issue. I'm tweaking the sync command so it stops dependent docker services, rebuilds the database (schema + data) from the dump, then starts up dependent docker services again.