### PR TITLE
OPS-13 use pip3 in makefile/update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean-pyc clean-build install
 
 install:
-	pip install -e .
+	pip3 install -e .
 
 clean:
 	rm -rf build/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sykle is a cli tool for calling commonly used commands in docker-compose project
 
 ### Requirements
 
-- `python 3.7` (may work on earlier versions of 3, but only tested on 3.7. Plugins do NOT work in python version 2.7)
+- `python 3.4` (may work on earlier versions of 3, but not tested. Plugins do NOT work in python version 2.7)
 - `docker` (locally and on deployment target)
 - `docker-compose` (locally and on deployment target)
 - `ssh`
@@ -28,7 +28,13 @@ Sykle is a cli tool for calling commonly used commands in docker-compose project
 
 ### Installation
 
+#### If python3 is your default installation, you can use pip
+
 `pip install git+ssh://git@github.com/typecode/sykle.git --upgrade`
+
+#### If you have a separate `python3` installation, you should use pip3
+
+`pip3 install git+ssh://git@github.com/typecode/sykle.git --upgrade`
 
 ### Configuration
 

--- a/README.mustache
+++ b/README.mustache
@@ -20,7 +20,7 @@ Sykle is a cli tool for calling commonly used commands in docker-compose project
 
 ### Requirements
 
-- `python 3.7` (may work on earlier versions of 3, but only tested on 3.7. Plugins do NOT work in python version 2.7)
+- `python 3.4` (may work on earlier versions of 3, but not tested. Plugins do NOT work in python version 2.7)
 - `docker` (locally and on deployment target)
 - `docker-compose` (locally and on deployment target)
 - `ssh`
@@ -28,7 +28,13 @@ Sykle is a cli tool for calling commonly used commands in docker-compose project
 
 ### Installation
 
+#### If python3 is your default installation, you can use pip
+
 `pip install git+ssh://git@github.com/typecode/sykle.git --upgrade`
+
+#### If you have a separate `python3` installation, you should use pip3
+
+`pip3 install git+ssh://git@github.com/typecode/sykle.git --upgrade`
 
 ### Configuration
 


### PR DESCRIPTION
### Overview

- Use pip3 in makefile (so it uses python3 on jenkins)
- Update README with instructions for how to install when python3 isn't your default