### PR TITLE
TASK/OPS-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,29 +61,9 @@ Usage instructions can be viewed after installation with `syk --help`
 
 This will not show any info for plugins. In order to view installed plugins, run `syk plugins`. To view help for a specfic plugin, run `syk <plugin_name> --help`.
 
-### Development
+#### Running Tests (for sykle)
 
-The README for the main package and each global plugin is generated via mustache (actual README.md files are read only). This allows us to insert the docstrings (which determine command line arguments) into each README so they stay up to date automatically.
-
-When you pull down the repo for the first time, you should run the following command:
-
-```sh
-git config core.hooksPath .githooks
-```
-
-This will make it so that after commit, if there has been a change to the docstrings, an additional "Update README" commit will be created with up to date documentation.
-
-#### Githook Requirements
-
-You will need to install `chevron` for the githooks to work:
-
-```sh
-pip install chevron
-```
-
-#### Running Tests
-
-Unittests can be run via `python setup.py test`
+Unittests (that test sykle) can be run via `python setup.py test`
 
 #### Writing plugins
 
@@ -98,7 +78,7 @@ To create a local plugin:
 1. Create a `.sykle-plugins/` directory in the root of your project (`.sykle-plugins/` should be in same directory as `.sykle.json`)
 2. Add an `__init__.py` file to `.sykle-plugins/`
 3. Add a python file for your plugin to `.sykle-plugins/` (EX: `.sykle-plugins/my_plugin.py`)
-4. Define your plugin like in the exapmle below:
+4. Define your plugin like in the example below:
 
 Example
 ```py
@@ -138,16 +118,14 @@ If you defined your plugin correctly, you should be able to see listed when call
 
 Global plugins are the same as local plugins, but they are added to the `plugins` folder of this repo and are available to anyone who installs sykle.
 
-Any `README.mustache` defined in a plugin folder will have a usage variable provided to it, and will result in a `README.md` being created when code is commited
-
 ### Roadmap
 
 - [x] Move to separate repo
 - [x] Allow user to specify `test` commands
 - [x] Add plugins
-- [x] REAMDE.md generation on ~push to repo~ commit
 - [x] Add `init` command to create `.sykle.json`
 - [x] ~Scripts section in `.sykle.json`~ Local plugins
+-  ~REAMDE.md generation on commit~ (unecessarily complex)
 - [ ] Fallback to `./run.sh` if it exists and `.sykle.json` does not
 - [ ] User aliases/way to share aliases
 - [ ] Terraform support

--- a/sykle/call_subprocess.py
+++ b/sykle/call_subprocess.py
@@ -23,7 +23,13 @@ def call_subprocess(command, env=None, debug=False, target=None):
             print('ENV:', env)
         print('--END COMMAND--')
 
-    if env:
-        subprocess.call(full_command, env=full_env, shell=True)
-    else:
-        subprocess.call(full_command, shell=True)
+    try:
+        if env:
+            p = subprocess.Popen(full_command, env=full_env, shell=True)
+        else:
+            p = subprocess.Popen(full_command, shell=True)
+        p.wait()
+        return p
+    except KeyboardInterrupt:
+        p.wait()
+        return p

--- a/sykle/cli.py
+++ b/sykle/cli.py
@@ -8,8 +8,8 @@ Usage:
   syk [--debug] [--config=<file>] [--test | --prod] [--deployment=<name>] build
   syk [--debug] [--config=<file>] [--test | --prod] up
   syk [--debug] [--config=<file>] [--test | --prod] down
-  syk [--debug] [--config=<file>] [--service=<service>] unittest [INPUT ...]
-  syk [--debug] [--config=<file>] [--service=<service>] e2e [INPUT ...]
+  syk [--debug] [--config=<file>] [--service=<service>] [--fast] unittest [INPUT ...]
+  syk [--debug] [--config=<file>] [--service=<service>] [--fast] e2e [INPUT ...]
   syk [--debug] [--config=<file>] [--deployment=<name>] push
   syk [--debug] [--config=<file>] [--deployment=<name>] ssh
   syk [--debug] [--config=<file>] [--deployment=<name>] [--dest=<dest>] ssh_cp [INPUT ...]
@@ -32,6 +32,8 @@ Option
   --service=<service>     Docker service on which to run the command
   --debug                 Prints debug information
   --deployment=<name>     Uses config for the given deployment
+  --fast                  Runs tests without building images/containers
+                          (you will need to have 'syk --test up' running)
 
 Description:
   dc              Runs docker-compose command
@@ -161,9 +163,15 @@ def main():
     elif args['down']:
         sykle.down(docker_type=docker_type)
     elif args['unittest']:
-        sykle.unittest(input=args['INPUT'], service=args['--service'])
+        sykle.unittest(
+            input=args['INPUT'], service=args['--service'],
+            fast=args['--fast']
+        )
     elif args['e2e']:
-        sykle.e2e(input=args['INPUT'], service=args['--service'])
+        sykle.e2e(
+            input=args['INPUT'], service=args['--service'],
+            fast=args['--fast']
+        )
     elif args['push']:
         docker_vars = config.docker_vars_for_deployment(deployment)
         sykle.push(docker_vars=docker_vars)

--- a/sykle/dc_runner.py
+++ b/sykle/dc_runner.py
@@ -1,4 +1,3 @@
-import subprocess
 from .call_subprocess import call_subprocess
 
 
@@ -43,13 +42,9 @@ class DCRunner():
             ['-f', self.docker_compose_file]
         )
 
-        try:
-            call_subprocess(
-                base_command + input,
-                debug=self.debug,
-                env=self.docker_vars,
-                target=self.target
-            )
-        except KeyboardInterrupt:
-            print('Exiting...')
-            subprocess.call(base_command + ['down'])
+        return call_subprocess(
+            base_command + input,
+            debug=self.debug,
+            env=self.docker_vars,
+            target=self.target
+        )


### PR DESCRIPTION
### Overview

- You can now use `syk --fast unittest` and `syk --fast e2e` in order to make tests run faster during development. To run those commands,  you'll need the test containers to be up and running in another window (via `syk --test up`). This is beneficial when builds are slow even with proper docker caching, or when starting services (like elasticsearch) is slow.
- They way keyboard interrupts were being interpreted before was a bit hacky and has been made nicer (would stop docker compose twice before, now stops like it would if you were interrupting docker compose directly).
- There was a typo in `dc_exec` that was preventing it from ever getting docker_vars that has been fixed.
- Updates documentation