### PR TITLE
Throw errors on failures/stop test support services

### DIFF
--- a/sykle/call_subprocess.py
+++ b/sykle/call_subprocess.py
@@ -7,6 +7,15 @@ class CancelException(Exception):
     pass
 
 
+class NonZeroReturnCodeException(Exception):
+    def __init__(self, process):
+        self.process = process
+        self.message = 'Process returned a non zero returncode'
+
+    def __str__(self):
+        return self.message
+
+
 def call_subprocess(command, env=None, debug=False, target=None):
     """
     This is a utility function that will spawn a subprocess that runs the
@@ -50,7 +59,8 @@ def call_subprocess(command, env=None, debug=False, target=None):
         else:
             p = subprocess.Popen(full_command, shell=True)
         p.wait()
-        return p
+        if p.returncode != 0:
+            raise NonZeroReturnCodeException(process=p)
     except KeyboardInterrupt:
         p.wait()
         raise CancelException()

--- a/sykle/cli.py
+++ b/sykle/cli.py
@@ -58,8 +58,8 @@ Description:
 from . import __version__
 from .plugin_utils import Plugins
 from .config import Config
-from .sykle import Sykle
-from .call_subprocess import call_subprocess, CancelException
+from .sykle import Sykle, CommandException
+from .call_subprocess import call_subprocess, CancelException, NonZeroReturnCodeException
 from docopt import docopt
 import os
 import sys
@@ -227,5 +227,9 @@ def main():
         process_args(args)
     except CancelException:
         print(CRED + '\nCancelled' + CEND)
+    except CommandException as e:
+        print(CRED + '\n{}'.format(e) + CEND)
     except Config.ConfigException as e:
-        print(CRED + str(e) + CEND)
+        print(CRED + '\n{}'.format(e) + CEND)
+    except NonZeroReturnCodeException as e:
+        print(CRED + '\n{}'.format(e) + CEND)

--- a/sykle/config.py
+++ b/sykle/config.py
@@ -25,6 +25,12 @@ class Command:
         self.service = service
         self.input = input.split(' ') if type(input) == str else input
 
+    def __str__(self):
+        return "(Service: \"{}\", Input: \"{}\")".format(
+            self.service,
+            ' '.join(self.input)
+        )
+
 
 class DeploymentConfig:
     @staticmethod


### PR DESCRIPTION
OVERVIEW

When commands fail, they will now return more user friendly error and stop
the execution of additional commands (such as in the deploy command)

Test commands will now also stop any containers that may have been spun up
in order to support a test command (when not run in "fast" mode)