### PR TITLE
Pass deployment env var to commands

### DIFF
--- a/sykle/sykle.py
+++ b/sykle/sykle.py
@@ -19,6 +19,11 @@ class Sykle():
         modified_kwargs = {**kwargs}
         docker_type = modified_kwargs.pop('docker_type', None)
 
+        env = modified_kwargs.get('env', {})
+        deployment = modified_kwargs.get('deployment')
+        if deployment:
+            env['DEPLOYMENT'] = deployment
+
         for command in commands:
             command.input += input
             try:
@@ -38,7 +43,7 @@ class Sykle():
                             **modified_kwargs
                         )
                 else:
-                    self.call_subprocess(command.input)
+                    self.call_subprocess(command.input, env=env)
             except NonZeroReturnCodeException:
                 raise CommandException("Command {} failed".format(command))
 


### PR DESCRIPTION
### Overview

- This passes a DEPLOYMENT env var to all commands

### Notes on env vars

The way in which env vars are passed around should be standardized; there are currently three ways env vars can be passed to things: through `docker_vars`, which are defined per deployments, through `env` files, which are paired to deployments/referenced by deployments, and an explicit `env` option when running certain commands. Those three different methods still seem appropriate to keep separate, but the fact that some are used in some contexts and others aren't should be fixed. This isn't addressed in this PR, is just an observation