### PR TITLE
Fix installation of dependencies via pip + bonus fix for ECS plugin usage documentation

### DIFF
--- a/sykle/__init__.py
+++ b/sykle/__init__.py
@@ -1,3 +1,1 @@
-from .sykle import Sykle
-
-__version__ = Sykle.version
+__version__ = '0.6.4'

--- a/sykle/plugins/ecs/__init__.py
+++ b/sykle/plugins/ecs/__init__.py
@@ -11,21 +11,21 @@ Description:
 
 Example .sykle.json:
   {
-    "plugins": {
-      "ecs": {
-        "production": {
-          "cluster": "foo-production",
-          "docker_vars": {
-            "BACKEND_IMAGE": "*****.amazonaws.com/foo-backend",
-            "BUILD_NUMBER": "latest"
-          }
+    "deployments": {
+      "production": {
+        "cluster": "foo-production",
+        "env_file": ".env.production",
+        "docker_vars": {
+          "BACKEND_IMAGE": "*****.amazonaws.com/foo-backend",
+          "BUILD_NUMBER": "latest"
         }
-        "staging": {
-          "cluster": "foo-staging",
-          "docker_vars": {
-            "BACKEND_IMAGE": "*****.amazonaws.com/foo-backend",
-            "BUILD_NUMBER": "latest"
-          }
+      },
+      "staging": {
+        "cluster": "foo-staging",
+        "env_file": ".env.staging",
+        "docker_vars": {
+          "BACKEND_IMAGE": "*****.amazonaws.com/foo-backend",
+          "BUILD_NUMBER": "latest"
         }
       }
     }

--- a/sykle/sykle.py
+++ b/sykle/sykle.py
@@ -1,3 +1,4 @@
+from . import __version__
 from .call_subprocess import (
     call_subprocess, NonZeroReturnCodeException,
     SubprocessExceptionHandler
@@ -12,7 +13,7 @@ class CommandException(Exception):
 class Sykle():
     """Class for programatically invoking Sykle."""
 
-    version = '0.6.3'
+    version = __version__
 
     def __init__(self, config, debug=False):
         self.config = config

--- a/test/sykle_test.py
+++ b/test/sykle_test.py
@@ -1,4 +1,4 @@
-from sykle import Sykle
+from sykle.sykle import Sykle
 from sykle.config import ConfigV2
 from unittest.mock import MagicMock
 import unittest


### PR DESCRIPTION
1. Noticed that attempting to install Sykle with pip results in an error
due to a missing `dotenv` dependency. Thus far, I believe we've been
chalking this up to some sort of fluke with how `install_requires` is
defined in setup.py, and working around the issue by manually
pre-installing python-dotenv (and other dependencies) in environments
where we install Sykle. Took a closer look and noticed that setup.py is
importing the `__version__` from __init__.py. This would be fine, except
that in __init__.py we're importing the `Sykle` class from `sykle.py`,
which in turn calls for the import of dotenv, among other modules. This
commit flips the structure so that the version is define in __init__.py
and pulled into the Sykle class, rather than the reverse.

2. Correct ecs plugin usage documentation