### PR TITLE
include plugin requirements in manifest and package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ exclude .coverage
 exclude htmlcov
 exclude installers
 include README.md
+include sykle/plugins/**/requirements.txt
 prune .git
 recursive-exclude *.egg-info *

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,9 @@ setup(
     ],
     test_suite='nose.collector',
     packages=find_packages(
-        exclude=('test',)
+        exclude=('test',),
     ),
+    package_data={'sykle': ['plugins/**/requirements.txt']},
     entry_points={
         'console_scripts': [
             'syk=sykle.cli:main',


### PR DESCRIPTION
so that pip includes them in the package source and `syk plugins install` and this line returns true: https://github.com/typecode/sykle/blob/develop/sykle/plugin_utils.py#L28