### PR TITLE
Fix project name flag for docker compose

### DIFF
--- a/sykle/call_docker_compose.py
+++ b/sykle/call_docker_compose.py
@@ -21,7 +21,7 @@ def call_docker_compose(
 
     opts = []
     project_command = []
-    project_command = ['-p', '{}-{}'.format(project_name, type)]
+    project_command = ['--project-name', '{}-{}'.format(project_name, type)]
 
     if env_file:
         # NB: docker compose has an --env-file option, but we're manually


### PR DESCRIPTION
- Change -p flag to --project-name for compatibility with docker compose CLI

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>